### PR TITLE
FO-2695: Endret tittel-teksten

### DIFF
--- a/src/main/java/no/nav/fo/veilarbdialog/db/dao/DialogDAO.java
+++ b/src/main/java/no/nav/fo/veilarbdialog/db/dao/DialogDAO.java
@@ -91,11 +91,11 @@ public class DialogDAO {
     }
 
     public int kasserHenvendelse(long id) {
-        return database.update("UPDATE HENVENDELSE SET TEKST = 'Det var skrevet noe feil, og det er nå slettet.' WHERE HENVENDELSE_ID = ?", id);
+        return database.update("UPDATE HENVENDELSE SET TEKST = '- Det var skrevet noe feil, og det er nå slettet. -' WHERE HENVENDELSE_ID = ?", id);
     }
 
     public int kasserDialog(long id) {
-        return database.update("UPDATE DIALOG SET OVERSKRIFT = 'Det var skrevet noe feil, og det er nå slettet.' WHERE DIALOG_ID = ?", id);
+        return database.update("UPDATE DIALOG SET OVERSKRIFT = '- Det var skrevet noe feil, og det er nå slettet. -' WHERE DIALOG_ID = ?", id);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/no/nav/fo/veilarbdialog/db/dao/DialogDAO.java
+++ b/src/main/java/no/nav/fo/veilarbdialog/db/dao/DialogDAO.java
@@ -95,7 +95,7 @@ public class DialogDAO {
     }
 
     public int kasserDialog(long id) {
-        return database.update("UPDATE DIALOG SET OVERSKRIFT = 'Kassert av NAV' WHERE DIALOG_ID = ?", id);
+        return database.update("UPDATE DIALOG SET OVERSKRIFT = 'Det var skrevet noe feil, og det er nå slettet.' WHERE DIALOG_ID = ?", id);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/no/nav/fo/veilarbdialog/db/dao/DialogDAO.java
+++ b/src/main/java/no/nav/fo/veilarbdialog/db/dao/DialogDAO.java
@@ -91,7 +91,7 @@ public class DialogDAO {
     }
 
     public int kasserHenvendelse(long id) {
-        return database.update("UPDATE HENVENDELSE SET TEKST = 'Kassert av NAV' WHERE HENVENDELSE_ID = ?", id);
+        return database.update("UPDATE HENVENDELSE SET TEKST = 'Det var skrevet noe feil, og det er nå slettet.' WHERE HENVENDELSE_ID = ?", id);
     }
 
     public int kasserDialog(long id) {


### PR DESCRIPTION
Gitt at jeg som bruker eller veileder har fått en dialogmelding eller aktivitet kassert så skal tittel-teksten være

"Det var skrevet noe feil, og det er nå slettet."

(Resten står som i dag med teksten "Kassert av NAV") 