### PR TITLE
Fikse bug ved uthenting av sistOppdatert

### DIFF
--- a/src/main/java/no/nav/fo/veilarbdialog/service/DialogDataService.java
+++ b/src/main/java/no/nav/fo/veilarbdialog/service/DialogDataService.java
@@ -53,8 +53,9 @@ public class DialogDataService {
 
     public Date hentSistOppdatertForBruker(Person person, String meg) {
         String aktorId = hentAktoerIdForPerson(person);
+        String aktorEllerIdentInnloggetBruker = auth.erEksternBruker()? hentAktoerIdForPerson(Person.fnr(meg)): meg;
         auth.harTilgangTilPersonEllerKastIngenTilgang(aktorId);
-        return dataVarehusDAO.hentSisteEndringSomIkkeErDine(aktorId, meg);
+        return dataVarehusDAO.hentSisteEndringSomIkkeErDine(aktorId, aktorEllerIdentInnloggetBruker);
     }
 
     @Transactional

--- a/src/test/java/no/nav/fo/veilarbdialog/rest/DialogRessursTest.java
+++ b/src/test/java/no/nav/fo/veilarbdialog/rest/DialogRessursTest.java
@@ -50,25 +50,6 @@ public class DialogRessursTest {
         jdbc.update("delete from EVENT where EVENT_ID = 0");
     }
 
-    @Test
-    public void sistOppdatert() {
-
-        jdbc.update("insert into DIALOG (DIALOG_ID, OPPDATERT) values (0, current_timestamp(6))");
-        jdbc.update("insert into EVENT (EVENT_ID, DIALOGID, EVENT, AKTOR_ID, LAGT_INN_AV, TIDSPUNKT) values (0, 0, 'DIALOG_OPPRETTET', '1337', '1337', CURRENT_TIMESTAMP)");
-        Timestamp timestamp = jdbc.queryForObject("select TIDSPUNKT from EVENT where EVENT_ID = 0", Timestamp.class);
-        assertThat(timestamp).isNotNull();
-
-        given()
-                .port(port)
-                .param("aktorId", "1337")
-                .get("/veilarbdialog/api/dialog/sistOppdatert")
-                .then()
-                .assertThat()
-                .statusCode(200)
-                .contentType(equalTo(MediaType.APPLICATION_JSON_VALUE))
-                .body("sistOppdatert", equalTo(timestamp.getTime()));
-
-    }
 
     /*@Test
     public void opprettOgHentDialoger() throws Exception {

--- a/src/test/java/no/nav/fo/veilarbdialog/rest/DialogRessursTest.java
+++ b/src/test/java/no/nav/fo/veilarbdialog/rest/DialogRessursTest.java
@@ -1,3 +1,4 @@
+
 package no.nav.fo.veilarbdialog.rest;
 
 import no.nav.fo.veilarbdialog.auth.AuthService;
@@ -25,10 +26,9 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@RunWith(SpringRunner.class)
-public class DialogRessursTest {
 
+public class DialogRessursTest {
+/*
     @LocalServerPort
     private int port;
 
@@ -51,7 +51,7 @@ public class DialogRessursTest {
     }
 
 
-    /*@Test
+    @Test
     public void opprettOgHentDialoger() throws Exception {
         dialogRessurs.nyHenvendelse(new NyHenvendelseDTO().setTekst("tekst"));
         val hentAktiviteterResponse = dialogRessurs.hentDialoger();

--- a/src/test/java/no/nav/fo/veilarbdialog/rest/RestServiceTest.java
+++ b/src/test/java/no/nav/fo/veilarbdialog/rest/RestServiceTest.java
@@ -2,6 +2,7 @@ package no.nav.fo.veilarbdialog.rest;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import io.restassured.response.Response;
 import no.nav.common.client.aktoroppslag.AktorOppslagClient;
 import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.Fnr;
@@ -20,13 +21,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.*;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.when;
 
@@ -35,6 +40,8 @@ import static org.mockito.Mockito.when;
 public class RestServiceTest {
     final static Fnr fnr = Fnr.of("1234");
     final static AktorId aktorId = AktorId.of("4321");
+    final static String veilederIdent = "V123456";
+
 
     @LocalServerPort
     private int port;
@@ -75,6 +82,8 @@ public class RestServiceTest {
         jdbc.update("delete from HENVENDELSE");
         jdbc.update("delete from DIALOG");
         jdbc.update("delete from DIALOG_AKTOR");
+        jdbc.update("delete from EVENT");
+
 
     }
 
@@ -149,19 +158,94 @@ public class RestServiceTest {
 
     }
 
+    @Test
+    public void sistOppdatert_brukerInnlogget_kunBrukerHarLest_returnererNull() {
+        jdbc.update("insert into EVENT (EVENT_ID, DIALOGID, EVENT, AKTOR_ID, LAGT_INN_AV, TIDSPUNKT) values (0, 0, 'DIALOG_OPPRETTET', ?, ?, CURRENT_TIMESTAMP)", aktorId.get(), aktorId.get());
+
+        mockHappyPathBruker();
+        fetchSistOppdatert()
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .contentType(equalTo(MediaType.APPLICATION_JSON_VALUE))
+                .body("sistOppdatert", equalTo(null));
+
+    }
+
+    @Test
+    public void sistOppdatert_veilederInnlogget_kunVeilederHarLest_returnererNull() {
+
+        jdbc.update("insert into EVENT (EVENT_ID, DIALOGID, EVENT, AKTOR_ID, LAGT_INN_AV, TIDSPUNKT) values (0, 0, 'DIALOG_OPPRETTET', ?, ?, CURRENT_TIMESTAMP)", aktorId.get(), veilederIdent);
+
+        mockHappyPathVeileder();
+        fetchSistOppdatert()
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .contentType(equalTo(MediaType.APPLICATION_JSON_VALUE))
+                .body("sistOppdatert", equalTo(null));
+
+    }
+
+    @Test
+    public void sistOppdatert_brukerInnlogget_veilederEndretSist_returnererTidspunkt() {
+        Timestamp brukerLest = Timestamp.valueOf(LocalDateTime.now().minusHours(1));
+        Timestamp veilederLest = Timestamp.valueOf(LocalDateTime.now());
+
+        jdbc.update("insert into EVENT (EVENT_ID, DIALOGID, EVENT, AKTOR_ID, LAGT_INN_AV, TIDSPUNKT) values (0, 0, 'DIALOG_OPPRETTET', ?, ?, ?)", aktorId.get(), aktorId.get(), brukerLest);
+        jdbc.update("insert into EVENT (EVENT_ID, DIALOGID, EVENT, AKTOR_ID, LAGT_INN_AV, TIDSPUNKT) values (1, 0, 'DIALOG_OPPRETTET', ?, ?, ?)", aktorId.get(), veilederIdent, veilederLest);
+
+        mockHappyPathBruker();
+
+        fetchSistOppdatert()
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .contentType(equalTo(MediaType.APPLICATION_JSON_VALUE))
+                .body("sistOppdatert", equalTo(veilederLest.getTime()));
+
+    }
+
+    @Test
+    public void sistOppdatert_veilederInnlogget_brukerEndretSist_returnererTidspunkt() {
+        Timestamp veilederLest = Timestamp.valueOf(LocalDateTime.now().minusHours(1));
+        Timestamp brukerLest = Timestamp.valueOf(LocalDateTime.now());
+
+        jdbc.update("insert into EVENT (EVENT_ID, DIALOGID, EVENT, AKTOR_ID, LAGT_INN_AV, TIDSPUNKT) values (0, 0, 'DIALOG_OPPRETTET', ?, ?, ?)", aktorId.get(), aktorId.get(), brukerLest);
+        jdbc.update("insert into EVENT (EVENT_ID, DIALOGID, EVENT, AKTOR_ID, LAGT_INN_AV, TIDSPUNKT) values (1, 0, 'DIALOG_OPPRETTET', ?, ?, ?)", aktorId.get(), veilederIdent, veilederLest);
+
+        mockHappyPathBruker();
+
+        fetchSistOppdatert()
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .contentType(equalTo(MediaType.APPLICATION_JSON_VALUE))
+                .body("sistOppdatert", equalTo(veilederLest.getTime()));
+
+    }
+
+    private Response fetchSistOppdatert() {
+        return given()
+                .param("aktorId", aktorId.get())
+                .get("/veilarbdialog/api/dialog/sistOppdatert");
+    }
+
     private void mockHappyPathVeileder(){
         when(authService.erEksternBruker()).thenReturn(false);
+        when(authService.getIdent()).thenReturn(Optional.of(veilederIdent));
+
         mockAuthOK();
     }
 
     private void mockHappyPathBruker(){
         when(authService.erEksternBruker()).thenReturn(true);
+        when(authService.getIdent()).thenReturn(Optional.of(fnr.get()));
         mockAuthOK();
     }
 
     private void mockAuthOK() {
 
-        when(authService.getIdent()).thenReturn(Optional.of(fnr.get()));
         when(authService.harTilgangTilPerson(aktorId.get())).thenReturn(true);
         when(aktorOppslagClient.hentAktorId(fnr)).thenReturn(aktorId);
 


### PR DESCRIPTION

Tror dette må være en bug, dersom  authContextHolder.getSubject() returnerer fnr og ikke aktørId
Gjør at eksternbruker får nytt timestamp selv om bruker selv var den som gjorde siste endring