### PR TITLE
Endrer slik at henvendelser opprettet av veileder skal markeres som ferdig behandlet

### DIFF
--- a/src/main/java/no/nav/fo/veilarbdialog/service/DialogStatusService.java
+++ b/src/main/java/no/nav/fo/veilarbdialog/service/DialogStatusService.java
@@ -119,6 +119,9 @@ public class DialogStatusService {
         dataVarehusDAO.insertEvent(dialogData, DatavarehusEvent.NY_HENVENDELSE_FRA_VEILEDER);
 
         Date eldsteUlesteForBruker = getEldsteUlesteForBruker(dialogData, henvendelseData);
+
+        oppdaterVenterPaNavSiden(dialogData, true);
+
         statusDAO.setEldsteUlesteForBruker(dialogData.getId(), eldsteUlesteForBruker);
         funksjonelleMetrikker.nyHenvendelseVeileder(dialogData);
     }

--- a/src/test/java/no/nav/fo/veilarbdialog/rest/DialogRessursTest.java
+++ b/src/test/java/no/nav/fo/veilarbdialog/rest/DialogRessursTest.java
@@ -106,8 +106,10 @@ public class DialogRessursTest {
 
     @Test
     public void nyHenvendelse_fraVeileder_venterIkkePaaNoen() {
+        //Veileder kan sende en beskjed som bruker ikke trenger å svare på, veileder må eksplisitt markere at dialogen venter på brukeren
         mockErVeileder();
         NyHenvendelseDTO nyHenvendelseDTO = new NyHenvendelseDTO().setTekst("tekst").setOverskrift("overskrift");
+
         DialogDTO dialog = dialogRessurs.nyHenvendelse(nyHenvendelseDTO);
 
         assertThat(dialog.venterPaSvar).isFalse();
@@ -116,19 +118,34 @@ public class DialogRessursTest {
 
     @Test
     public void nyHenvendelse_veilederSvarerPaaBrukersHenvendelse_venterIkkePaaNav() {
-        // Hvis dialogen venter på nav og nav sender en ny melding i dialogen, så skal venter på nav markering fjernes
-        //Det skjer nå i frontend ved kall til /ferdigbehandlet men det skal fjernes
 
         mockErEksternBruker();
         NyHenvendelseDTO brukersHenvendelse = new NyHenvendelseDTO().setTekst("tekst").setOverskrift("overskrift");
         DialogDTO brukersDialog = dialogRessurs.nyHenvendelse(brukersHenvendelse);
 
         mockErVeileder();
-        dialogRessurs.oppdaterFerdigbehandlet(brukersDialog.id, true); //TODO: skal fjernes
         NyHenvendelseDTO veiledersHenvendelse = new NyHenvendelseDTO().setTekst("tekst");
         DialogDTO veiledersDialog = dialogRessurs.nyHenvendelse(veiledersHenvendelse.setDialogId(brukersDialog.id));
 
         assertThat(veiledersDialog.ferdigBehandlet).isTrue();
+    }
+
+    @Test
+    public void nyHenvendelse_brukerSvarerPaaVeiledersHenvendelse_venterPaNav() {
+
+        mockErVeileder();
+        NyHenvendelseDTO veiledersHenvendelse = new NyHenvendelseDTO().setTekst("tekst").setOverskrift("overskrift");
+        DialogDTO veiledersDialog = dialogRessurs.nyHenvendelse(veiledersHenvendelse);
+
+        assertThat(veiledersDialog.ferdigBehandlet).isTrue();
+
+        mockErEksternBruker();
+        NyHenvendelseDTO brukersHenvendelse = new NyHenvendelseDTO().setTekst("tekst");
+        dialogRessurs.nyHenvendelse(brukersHenvendelse.setDialogId(veiledersDialog.id));
+
+        mockErVeileder();
+        veiledersDialog = dialogRessurs.hentDialog(veiledersDialog.id);
+        assertThat(veiledersDialog.ferdigBehandlet).isFalse();
     }
 
     @Test


### PR DESCRIPTION
For å unngå race condition når det sendes to kall fra frontend når man sender to requester. 
Frontend oppretter først dialog og deretter markerer som ferdig behandlet, begge deler legger ting på samme kafka topic.

https://trello.com/c/MeSvurKy/229-venter-p%C3%A5-svar-fra-nav-blir-noen-ganger-ikke-fjernet-i-portef%C3%B8lje-n%C3%A5r-veileder-sender-henvendelse

Blir endel forenklet når jeg får merga den andre pull requesten 
https://github.com/navikt/veilarbdialog/pull/110