### PR TITLE
Ta bort secure logs logback-config

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <include resource="no/nav/common/log/logback-default.xml"/>
+    <include resource="no/nav/common/log/logback-stdout-json.xml"/>
+    <include resource="no/nav/common/log/logback-naudit.xml"/>
+    <include resource="no/nav/common/log/logback-cxf.xml"/>
     <!-- Logger cookies dersom det ikke parses riktig. Dette kan fjernes i versjon 2.2020.10.13_14.48-80e4c2dc5856 av common eller nyere -->
     <logger name="org.apache.tomcat.util.http.parser.Cookie" level="OFF" />
 </configuration>


### PR DESCRIPTION
secureLogs er ikke enabled, dermed mountes ikke mappe for securelogs, og logger blir forsøkt skrivet til en mappe uten tilgang.