### PR TITLE
Legg til inbound rule for mulighetsrommet-api

### DIFF
--- a/nais/nais-dev.yaml
+++ b/nais/nais-dev.yaml
@@ -71,6 +71,9 @@ spec:
         - application: veilarbpersonflate
           namespace: poao
           cluster: dev-gcp
+        - application: mulighetsrommet-api
+          namespace: team-mulighetsrommet
+          cluster: dev-gcp
   env:
     - name: APP_ENVIRONMENT_NAME
       value: q1

--- a/nais/nais-prod.yaml
+++ b/nais/nais-prod.yaml
@@ -69,6 +69,9 @@ spec:
         - application: veilarbpersonflate
           namespace: poao
           cluster: prod-gcp
+        - application: mulighetsrommet-api
+          namespace: team-mulighetsrommet
+          cluster: prod-gcp
   env:
     - name: APP_ENVIRONMENT_NAME
       value: p


### PR DESCRIPTION
Vi ønsker å sende dialogmeldingen fra vårt api i stedet for rett fra frontend, så derfor trenger vi å legge til inbound rule for mulighetsrommet-api. 