### PR TITLE
🚫   Bruk azure m2m for oppfolging-client for eksterne

### DIFF
--- a/src/main/java/no/nav/fo/veilarbdialog/config/FilterConfig.java
+++ b/src/main/java/no/nav/fo/veilarbdialog/config/FilterConfig.java
@@ -6,14 +6,12 @@ import no.nav.common.auth.oidc.filter.OidcAuthenticationFilter;
 import no.nav.common.auth.oidc.filter.OidcAuthenticatorConfig;
 import no.nav.common.rest.filter.LogRequestFilter;
 import no.nav.common.rest.filter.SetStandardHttpHeadersFilter;
-import no.nav.common.token_client.builder.AzureAdTokenClientBuilder;
 import no.nav.fo.veilarbdialog.util.PingFilter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import no.nav.common.token_client.client.AzureAdOnBehalfOfTokenClient;
 
 import java.util.List;
 

--- a/src/main/java/no/nav/fo/veilarbdialog/config/VeilarboppfolgingClient.java
+++ b/src/main/java/no/nav/fo/veilarbdialog/config/VeilarboppfolgingClient.java
@@ -2,8 +2,9 @@ package no.nav.fo.veilarbdialog.config;
 
 import lombok.extern.slf4j.Slf4j;
 import no.nav.common.rest.client.RestUtils;
-import no.nav.common.sts.SystemUserTokenProvider;
+import no.nav.common.token_client.client.AzureAdMachineToMachineTokenClient;
 import no.nav.common.token_client.client.AzureAdOnBehalfOfTokenClient;
+import no.nav.common.token_client.client.TokenXOnBehalfOfTokenClient;
 import no.nav.common.utils.UrlUtils;
 import no.nav.fo.veilarbdialog.auth.AuthService;
 import okhttp3.OkHttpClient;
@@ -33,14 +34,17 @@ public class VeilarboppfolgingClient {
     public VeilarboppfolgingClient(
             @Value("${application.veilarboppfolging.api.scope}") String veilarboppfolgingapiScope,
             AzureAdOnBehalfOfTokenClient azureAdOnBehalfOfTokenClient,
-            SystemUserTokenProvider systemUserTokenProvider,
+            AzureAdMachineToMachineTokenClient azureAdMachineToMachineTokenClient,
+            TokenXOnBehalfOfTokenClient tokenXOnBehalfOfTokenClient,
             OkHttpClient client,
             AuthService auth) {
         this.tokenProvider = () -> {
             if (auth.erInternBruker()) {
                 return azureAdOnBehalfOfTokenClient.exchangeOnBehalfOfToken(veilarboppfolgingapiScope, auth.getInnloggetBrukerToken());
+            } else if (auth.erEksternBruker()) {
+                return tokenXOnBehalfOfTokenClient.exchangeOnBehalfOfToken(veilarboppfolgingapiScope, auth.getInnloggetBrukerToken());
             } else {
-                return systemUserTokenProvider.getSystemUserToken();
+                return azureAdMachineToMachineTokenClient.createMachineToMachineToken(veilarboppfolgingapiScope);
             }
         };
         this.client = client;

--- a/src/main/java/no/nav/fo/veilarbdialog/service/ServiceConfig.java
+++ b/src/main/java/no/nav/fo/veilarbdialog/service/ServiceConfig.java
@@ -6,8 +6,10 @@ import no.nav.common.featuretoggle.UnleashClientImpl;
 import no.nav.common.sts.NaisSystemUserTokenProvider;
 import no.nav.common.sts.SystemUserTokenProvider;
 import no.nav.common.token_client.builder.AzureAdTokenClientBuilder;
+import no.nav.common.token_client.builder.TokenXTokenClientBuilder;
 import no.nav.common.token_client.client.AzureAdMachineToMachineTokenClient;
 import no.nav.common.token_client.client.AzureAdOnBehalfOfTokenClient;
+import no.nav.common.token_client.client.TokenXOnBehalfOfTokenClient;
 import no.nav.common.utils.Credentials;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -50,6 +52,15 @@ public class ServiceConfig {
     @Profile("!local")
     public AzureAdOnBehalfOfTokenClient azureAdOnBehalfOfTokenClient() {
         return AzureAdTokenClientBuilder.builder()
+                .withNaisDefaults()
+                .buildOnBehalfOfTokenClient();
+    }
+
+    @Profile("!local")
+    @Bean
+    public TokenXOnBehalfOfTokenClient tokenXOnBehalfOfTokenClient() {
+        return TokenXTokenClientBuilder
+                .builder()
                 .withNaisDefaults()
                 .buildOnBehalfOfTokenClient();
     }

--- a/src/test/java/no/nav/fo/veilarbdialog/config/ApplicationTestConfig.java
+++ b/src/test/java/no/nav/fo/veilarbdialog/config/ApplicationTestConfig.java
@@ -4,6 +4,7 @@ import no.nav.common.featuretoggle.UnleashClient;
 import no.nav.common.sts.SystemUserTokenProvider;
 import no.nav.common.token_client.client.AzureAdMachineToMachineTokenClient;
 import no.nav.common.token_client.client.AzureAdOnBehalfOfTokenClient;
+import no.nav.common.token_client.client.TokenXOnBehalfOfTokenClient;
 import org.mockito.Mockito;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -37,6 +38,13 @@ public class ApplicationTestConfig {
     public AzureAdOnBehalfOfTokenClient azureAdOnBehalfOfTokenClient() {
         AzureAdOnBehalfOfTokenClient tokenClient = mock(AzureAdOnBehalfOfTokenClient.class);
         Mockito.when(tokenClient.exchangeOnBehalfOfToken(any(), any())).thenReturn("mockMachineToMachineToken");
+        return tokenClient;
+    }
+
+    @Bean
+    public TokenXOnBehalfOfTokenClient tokenXOnBehalfOfTokenClient() {
+        TokenXOnBehalfOfTokenClient tokenClient = mock(TokenXOnBehalfOfTokenClient.class);
+        Mockito.when(tokenClient.exchangeOnBehalfOfToken(any(), any())).thenReturn("tokenxOBOToken");
         return tokenClient;
     }
 


### PR DESCRIPTION
Kan ikke merges enda fordi veilarboppfølging krever enten Intern eller system-kontekst. Ser ikke ut til å støtte Azure m2m tokens heller, men bruker fortsatt ABAC og slik jeg har forstått det så kan man ikke sende Azure tokens til ABAC