### PR TITLE
c gir tilgang til aia-backend i accessPolicy

### DIFF
--- a/nais/nais-dev.yaml
+++ b/nais/nais-dev.yaml
@@ -85,6 +85,9 @@ spec:
         - application: arbeidsrettet-dialog
           namespace: pto
           cluster: dev-gcp
+        - application: aia-backend
+          namespace: paw
+          cluster: dev-gcp
   env:
     - name: APP_ENVIRONMENT_NAME
       value: q1

--- a/nais/nais-prod.yaml
+++ b/nais/nais-prod.yaml
@@ -83,6 +83,9 @@ spec:
         - application: arbeidsrettet-dialog
           namespace: pto
           cluster: prod-gcp
+        - application: aia-backend
+          namespace: paw
+          cluster: prod-gcp
   env:
     - name: APP_ENVIRONMENT_NAME
       value: p


### PR DESCRIPTION
For å slippe å gå via pto-proxy, som er på vei ut, trenger aia-backend tilgang