### PR TITLE
mindre oppgraderinger, og mer realistisk varselurl pga ny validering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
         <start-class>no.nav.fo.veilarbdialog.Application</start-class>
 
-        <common.version>4.2026.04.23_09.42-032a099e928f</common.version>
+        <common.version>4.2026.04.24_05.25-cab3c16705f7</common.version>
         <dab.common.version>2026.04.20-16.33.4a120cb625c2</dab.common.version>
         <poao.tilgang.version>2025.11.03_13.40-18456d0598be</poao.tilgang.version>
         <shedlock.version>7.7.0</shedlock.version>
@@ -101,7 +101,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -401,7 +401,7 @@
         <dependency>
             <groupId>no.nav.tms.varsel</groupId>
             <artifactId>kotlin-builder</artifactId>
-            <version>2.1.1</version>
+            <version>2.2.0</version>
         </dependency>
 
     </dependencies>
@@ -510,7 +510,7 @@
                 <groupId>org.openapitools</groupId>
                 <artifactId>openapi-generator-maven-plugin</artifactId>
                 <!-- RELEASE_VERSION -->
-                <version>7.19.0</version>
+                <version>7.21.0</version>
                 <!-- /RELEASE_VERSION -->
                 <executions>
                     <execution>

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -87,7 +87,7 @@ application:
     username: sa
     password: sa
   dialog:
-    url: http://localhost:8080/DIALOG_EKSTERN_URL
+    url: https://www.nav.no/arbeid/dialog-test
   kafka:
     broker:
       url: http://localhost:8080/KAFKA_BROKERS_URL


### PR DESCRIPTION
- endrer fra spring-boot-starter-web -> spring-boot-starter-webmvc som jeg glemte ifm springboot-oppgradering
- ny versjon av common
- to mindre oppgraderinger, men varsel-oppgraderingen har strengere validering på lenken, derfor må vi ha en mer realistisk lenke som peker til et nav.no-domene