### PR TITLE
Tilgangsendringer

### DIFF
--- a/src/main/java/no/nav/fo/veilarbdialog/eskaleringsvarsel/EskaleringsvarselController.java
+++ b/src/main/java/no/nav/fo/veilarbdialog/eskaleringsvarsel/EskaleringsvarselController.java
@@ -38,7 +38,7 @@ public class EskaleringsvarselController {
     @PostMapping(value = "/start")
     @OnlyInternBruker
     public EskaleringsvarselDto start(@RequestBody StartEskaleringDto startEskaleringDto) {
-        authService.sjekkTilgangTilPerson(startEskaleringDto.fnr(), TilgangsType.LESE);
+        authService.sjekkTilgangTilPerson(startEskaleringDto.fnr(), TilgangsType.SKRIVE);
         EskaleringsvarselEntity eskaleringsvarselEntity = eskaleringsvarselService.start(startEskaleringDto);
         return EskaleringsvarselDto.fromEntity(eskaleringsvarselEntity);
     }
@@ -46,7 +46,7 @@ public class EskaleringsvarselController {
     @PatchMapping("/stop")
     @OnlyInternBruker
     public void stop(@RequestBody StopEskaleringDto stopEskaleringDto) {
-        authService.sjekkTilgangTilPerson(stopEskaleringDto.fnr(), TilgangsType.LESE);
+        authService.sjekkTilgangTilPerson(stopEskaleringDto.fnr(), TilgangsType.SKRIVE);
         NavIdent navIdent = authService.getInnloggetVeilederIdent();
 
         Optional<EskaleringsvarselEntity> eskaleringsvarselEntity = eskaleringsvarselService.stop(stopEskaleringDto, navIdent);

--- a/src/main/java/no/nav/fo/veilarbdialog/rest/DialogRessurs.java
+++ b/src/main/java/no/nav/fo/veilarbdialog/rest/DialogRessurs.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.security.SecuritySchemes;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import no.nav.common.types.identer.EksternBrukerId;
 import no.nav.fo.veilarbdialog.domain.*;
 import no.nav.fo.veilarbdialog.kvp.KontorsperreFilter;
 import no.nav.fo.veilarbdialog.service.DialogDataService;
@@ -134,18 +133,6 @@ public class DialogRessurs {
         return restMapper.somDialogDTO(dialogData);
     }
 
-    private void sjekkTilgangOgAuditlog(EksternBrukerId bruker) {
-        var subject = auth.getLoggedInnUser();
-        try {
-            auth.sjekkTilgangTilPerson(bruker, TilgangsType.SKRIVE);
-        } catch (Exception e) {
-            auth.auditlog(false, subject , bruker, "ny melding");
-            throw e;
-        }
-        // Litt tidlig audit-logging men men
-        auth.auditlog(true, subject , bruker, "ny melding");
-    }
-
     @Operation(
         summary = "Oppretter en ny dialog tråd og/eller en ny melding i oppgitt dialogtråd",
         description = """
@@ -160,7 +147,7 @@ public class DialogRessurs {
             @RequestBody NyMeldingDTO nyMeldingDTO
     ) {
         Person bruker = nyMeldingDTO.getFnr() != null ? Person.fnr(nyMeldingDTO.getFnr()) : getContextUserIdent();
-        sjekkTilgangOgAuditlog(bruker.eksternBrukerId());
+        auth.sjekkTilgangTilPerson(bruker.eksternBrukerId(), TilgangsType.SKRIVE);
 
         var skalSendeMelding = !auth.erEksternBruker();
         var dialogData = dialogDataService.opprettMelding(nyMeldingDTO, bruker, skalSendeMelding);

--- a/src/main/java/no/nav/fo/veilarbdialog/rest/KladdRessurs.java
+++ b/src/main/java/no/nav/fo/veilarbdialog/rest/KladdRessurs.java
@@ -42,7 +42,7 @@ public class KladdRessurs {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void oppdaterKladd(@RequestBody KladdDTO kladd) {
         var fnr = getContextUserIdent(kladd);
-        authService.sjekkTilgangTilPerson(Fnr.of(fnr), TilgangsType.LESE);
+        authService.sjekkTilgangTilPerson(Fnr.of(fnr), TilgangsType.SKRIVE);
         kladdService.upsertKladd(fnr, somKladd(kladd));
     }
 


### PR DESCRIPTION
- endrer til å kreve skrivetilgang (modia oppfølging) for oppretting av kladd så det er samme regel som for sending av melding
- endrer til å kreve skrivetilgang for start/stopp av eskaleringsvarsel så det stemmer med sjekken frontend gjør for å avgjøre om knappen skal vises eller ikke
- fjerner auditlogg for oppretting av melding siden skriveoperasjoner ikke skal auditlogges

https://trello.com/c/TFMzLa8B/1608-s12-flere-muterende-endepunkter-sjekker-kun-for-tilgangstypelese-veilarbdialog