### PR TITLE
Tilgangsinformasjon

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,8 @@ Sist oppdatert 12.05.26
 - `ferdigBehandlet` er `venterPaNavSiden` (fra databasen) == null
 - Koden holder styr på **eldste uleste** for brukere men **nyeste uleste** for veiledere
 - "Funksjonelle metrikker" funker ikke etter at vi gikk over til GCP
+
+## Tilgangskontroll
+Appen bruker poao-tilgang for tilgangskontroll. For å kunne skrive en dialogmelding til bruker må innlogget veileder ha 
+tilgang til brukeren etter vanlige regler som finnes i tilgangsmaskinen. I tillegg kreves rollen `0000-GA-Modia-Oppfolging`. 
+Hvis veileder kun har rollen `0000-GA-BD06_ModiaGenerellTilgang` skal de få se dialogen, men de kan ikke skrive noe. 

--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
 
         <start-class>no.nav.fo.veilarbdialog.Application</start-class>
 
-        <common.version>4.2026.05.05_06.25-f72fab488a93</common.version>
-        <dab.common.version>2026.05.08-13.34.cc03ad5613af</dab.common.version>
+        <common.version>4.2026.05.15_08.54-961583f8b296</common.version>
+        <dab.common.version>2026.05.11-16.10.4d6c1e3c3451</dab.common.version>
         <poao.tilgang.version>4.2026.05.11_07.01-54ab6eae4dde</poao.tilgang.version>
         <shedlock.version>7.7.0</shedlock.version>
         <okhttp.version>5.3.2</okhttp.version>
@@ -115,7 +115,7 @@
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-annotations</artifactId>
-            <version>2.2.49</version>
+            <version>2.2.50</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -300,7 +300,7 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>libraries-bom</artifactId>
-            <version>26.80.0</version>
+            <version>26.83.0</version>
             <type>pom</type>
         </dependency>
 

--- a/src/main/java/no/nav/fo/veilarbdialog/graphql/DialogGraphqlController.java
+++ b/src/main/java/no/nav/fo/veilarbdialog/graphql/DialogGraphqlController.java
@@ -13,6 +13,7 @@ import no.nav.fo.veilarbdialog.kvp.KontorsperreFilter;
 import no.nav.fo.veilarbdialog.rest.RestMapper;
 import no.nav.fo.veilarbdialog.service.DialogDataService;
 import no.nav.fo.veilarbdialog.service.KladdService;
+import no.nav.poao.dab.spring_auth.AuthResult;
 import no.nav.poao.dab.spring_auth.AuthService;
 import no.nav.poao.dab.spring_auth.TilgangsType;
 import org.springframework.graphql.data.method.annotation.Argument;
@@ -86,6 +87,17 @@ public class DialogGraphqlController {
         return eskaleringsvarselService.historikk(targetFnr)
                 .stream().map(EskaleringsvarselDto::fromEntity)
                 .toList();
+    }
+
+    @QueryMapping
+    public TilgangTilBrukerDto tilgang(@Argument String fnr) {
+        var targetFnr = Fnr.of(getContextUserIdent(fnr).get());
+        var result = authService.harTilgangTilPerson(targetFnr, TilgangsType.SKRIVE);
+        if (result instanceof AuthResult.UserSuccessResult || result instanceof AuthResult.UnAuditedSuccessResult) {
+            return new TilgangTilBrukerDto(true);
+        } else {
+            return new TilgangTilBrukerDto(false);
+        }
     }
 
     private Predicate<DialogData> bareMedAktiviteterFilter(Optional<Boolean> bareMedAktiviteter) {

--- a/src/main/java/no/nav/fo/veilarbdialog/graphql/GraphqlResult.java
+++ b/src/main/java/no/nav/fo/veilarbdialog/graphql/GraphqlResult.java
@@ -33,6 +33,7 @@ class Dialoger {
     GjeldendeEskaleringsvarselDto stansVarsel;
     List<KladdDTO> kladder;
     List<EskaleringsvarselDto> stansVarselHistorikk;
+    TilgangTilBrukerDto tilgang;
 }
 
 @Data

--- a/src/main/kotlin/no/nav/fo/veilarbdialog/graphql/TilgangTilBrukerDto.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbdialog/graphql/TilgangTilBrukerDto.kt
@@ -1,0 +1,5 @@
+package no.nav.fo.veilarbdialog.graphql
+
+data class TilgangTilBrukerDto(
+    val harSkrivetilgangTilBruker: Boolean,
+)

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -3,6 +3,7 @@ type Query {
     stansVarsel(fnr: String!): GjeldendeEskaleringsvarselDto
     kladder(fnr: String!): [Kladd]
     stansVarselHistorikk(fnr: String!): [EskaleringsvarselDto]
+    tilgang(fnr: String!): TilgangTilBrukerDto
 }
 
 type Kladd {
@@ -31,6 +32,10 @@ type EskaleringsvarselDto {
     avsluttetDato: ZonedDateTime,
     avsluttetAv: String,
     avsluttetBegrunnelse: String
+}
+
+type TilgangTilBrukerDto {
+    harSkrivetilgangTilBruker: Boolean
 }
 
 scalar Date

--- a/src/test/java/no/nav/fo/veilarbdialog/graphql/DialogGraphqlControllerTest.java
+++ b/src/test/java/no/nav/fo/veilarbdialog/graphql/DialogGraphqlControllerTest.java
@@ -227,6 +227,31 @@ public class DialogGraphqlControllerTest extends SpringBootTestBase {
         assertThat(result.errors).isNull();
     }
 
+    @Test
+    void bruker_skal_ha_skrivetilgang() {
+        var result = graphqlRequest(bruker, "", tilgangQuery);
+        assertThat(result.getData().tilgang).isNotNull();
+        assertThat(result.getData().tilgang.getHarSkrivetilgangTilBruker()).isTrue();
+        assertThat(result.errors).isNull();
+    }
+
+    @Test
+    void veileder_med_skrivetilgang_skal_ha_skrivetilgang() {
+        var result = graphqlRequest(veileder, bruker.getFnr(), tilgangQuery);
+        assertThat(result.getData().tilgang).isNotNull();
+        assertThat(result.getData().tilgang.getHarSkrivetilgangTilBruker()).isTrue();
+        assertThat(result.errors).isNull();
+    }
+
+    @Test
+    void veileder_uten_skrivetilgang_skal_ikke_ha_skrivetilgang() {
+        var veilederUtenTilgang = MockNavService.createVeilederMedLesetilgang();
+        var result = graphqlRequest(veilederUtenTilgang, bruker.getFnr(), tilgangQuery);
+        assertThat(result.getData().tilgang).isNotNull();
+        assertThat(result.getData().tilgang.getHarSkrivetilgangTilBruker()).isFalse();
+        assertThat(result.errors).isNull();
+    }
+
     static String varselOmStans = """
                 query($fnr: String!) {
                     stansVarsel(fnr: $fnr) {
@@ -295,5 +320,13 @@ public class DialogGraphqlControllerTest extends SpringBootTestBase {
                         kontorsperreEnhetId
                     }
                 }   
+            """.trim().replace("\n", "");
+
+    static String tilgangQuery = """
+                query($fnr: String!) {
+                    tilgang(fnr: $fnr) {
+                        harSkrivetilgangTilBruker
+                    }
+                }
             """.trim().replace("\n", "");
 }

--- a/src/test/java/no/nav/fo/veilarbdialog/mock_nav_modell/MockNavService.java
+++ b/src/test/java/no/nav/fo/veilarbdialog/mock_nav_modell/MockNavService.java
@@ -1,11 +1,17 @@
 package no.nav.fo.veilarbdialog.mock_nav_modell;
 
+import no.nav.poao_tilgang.core.domain.AdGrupper;
+import no.nav.poao_tilgang.core.provider.NavEnhetTilgang;
+import no.nav.poao_tilgang.poao_tilgang_test_core.AdGruppeProviderImpl;
 import no.nav.poao_tilgang.poao_tilgang_test_core.NavAnsatt;
 import no.nav.poao_tilgang.poao_tilgang_test_core.NavContext;
 import no.nav.poao_tilgang.poao_tilgang_test_core.PrivatBruker;
 
+import static java.util.Collections.emptyList;
+
 public class MockNavService {
     public static final NavContext NAV_CONTEXT = new NavContext();
+    private static final AdGrupper tilgjengligeAdGrupper = new AdGruppeProviderImpl(NAV_CONTEXT).hentTilgjengeligeAdGrupper();
     public static MockBruker createHappyBruker() {
         return createBruker(BrukerOptions.happyBruker());
     }
@@ -53,6 +59,14 @@ public class MockNavService {
 
 
         return new MockVeileder(navAnsatt.getNavIdent());
+    }
+
+    public static MockVeileder createVeilederMedLesetilgang() {
+        NavAnsatt navAnsatt = new NavAnsatt();
+        NAV_CONTEXT.getNavAnsatt().add(navAnsatt);
+        navAnsatt.getAdGrupper().add(tilgjengligeAdGrupper.getGosysNasjonal());
+        navAnsatt.getEnheter().add(new NavEnhetTilgang("0000", "NAV Viken", emptyList()));
+        return  new MockVeileder(navAnsatt.getNavIdent());
     }
 
     private static String aktorIdFromFnr(String fnr) {

--- a/src/test/java/no/nav/fo/veilarbdialog/mock_nav_modell/MockNavService.java
+++ b/src/test/java/no/nav/fo/veilarbdialog/mock_nav_modell/MockNavService.java
@@ -66,7 +66,7 @@ public class MockNavService {
         NAV_CONTEXT.getNavAnsatt().add(navAnsatt);
         navAnsatt.getAdGrupper().add(tilgjengligeAdGrupper.getGosysNasjonal());
         navAnsatt.getEnheter().add(new NavEnhetTilgang("0000", "NAV Viken", emptyList()));
-        return  new MockVeileder(navAnsatt.getNavIdent());
+        return new MockVeileder(navAnsatt.getNavIdent());
     }
 
     private static String aktorIdFromFnr(String fnr) {


### PR DESCRIPTION
- legger til informasjon i graphql-endepunktet om tilgang til bruker som skal brukes av frontend for å avgjøre om innlogget veileder skal få se readonly-versjon av dialogen pga manglende tilgang (mangler rollen "modia oppfølging")
- oppdaterer avhengigheter

https://trello.com/c/JH01gQz0/1615-veileder-som-ikke-har-tilgang-til-%C3%A5-sende-dialogmelding-f%C3%A5r-likevel-opp-muligheten-i-flaten